### PR TITLE
Add glass background styling to home sections

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -115,7 +115,7 @@ const PropertyGallery: FC<{ projects: Project[] }> = ({ projects }) => {
   const { t } = useTranslation();
   const sectionRef = useScrollAnimate({ threshold: 0.05 });
   return (
-    <section id="gallery-section" className="section scroll-animate" ref={sectionRef}>
+    <section id="gallery-section" className="section glass-section scroll-animate" ref={sectionRef}>
       <div className="container">
         <h2 className="section-title" dangerouslySetInnerHTML={{ __html: t('galleryTitle') }} />
         <div className="grid">
@@ -132,7 +132,7 @@ const ServicesSection: FC = () => {
   const { t } = useTranslation();
   const sectionRef = useScrollAnimate({ threshold: 0.1 });
   return (
-    <section id="services" className="section scroll-animate" ref={sectionRef}>
+    <section id="services" className="section glass-section scroll-animate" ref={sectionRef}>
       <div className="container">
         <h2 className="section-title" data-i18n="ourServices" dangerouslySetInnerHTML={{ __html: t('ourServices') }} />
         <div className="services-grid">
@@ -182,7 +182,7 @@ const AboutSection: FC = () => {
   const [activeTab, setActiveTab] = useState('about');
   const sectionRef = useScrollAnimate();
   return (
-    <section id="about-section" className="section scroll-animate" ref={sectionRef}>
+    <section id="about-section" className="section glass-section scroll-animate" ref={sectionRef}>
       <div className="container">
         <div className="segbar">
           <button
@@ -239,7 +239,7 @@ const ContactForm: FC = () => {
     window.open(url, '_blank');
   };
   return (
-    <section id="contact" className="section scroll-animate" ref={sectionRef}>
+    <section id="contact" className="section glass-section scroll-animate" ref={sectionRef}>
       <div className="container">
         <h2 className="section-title" dangerouslySetInnerHTML={{ __html: t('requestCallback') }} />
         <div className="contact">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,12 +1,12 @@
 /* ===== تحديث الألوان ليكون الدهبي الأساسي أغمق + خلفيات زجاجية سوداء شفافة ===== */
 :root {
---gold: #DAA520; /* دهبي غامق (GoldenRod) */
---gold-2: #B8860B; /* دهبي ثانوي أغمق */
---panel-bg: rgba(0, 0, 0, 0.6); /* خلفية سوداء شفافة */
---muted: #B0BEC5;
---text: #FFFFFF;
---border: rgba(218, 165, 32, 0.5); /* حدود دهبية أغمق */
---border-glass: rgba(218, 165, 32, 0.35);}
+  --gold: #DAA520; /* دهبي غامق (GoldenRod) */
+  --gold-2: #B8860B; /* دهبي ثانوي أغمق */
+  --panel-bg: rgba(0, 0, 0, 0.6); /* خلفية سوداء شفافة */
+  --muted: #B0BEC5;
+  --text: #FFFFFF;
+  --border: rgba(218, 165, 32, 0.5); /* حدود دهبية أغمق */
+  --border-glass: rgba(218, 165, 32, 0.35);
 }
 * {
   box-sizing: border-box;
@@ -416,6 +416,13 @@ main {
 /* ===== الأقسام الموحدة ===== */
 .section {
   padding-block: 64px;
+}
+
+.glass-section {
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid var(--border-glass);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 main > .section {
@@ -887,6 +894,11 @@ main > .section:first-of-type {
   -webkit-backdrop-filter: blur(8px);
 }
 
+.glass-section .segbar {
+  background: rgba(18, 18, 18, 0.55);
+  color: var(--text);
+}
+
 .seg-btn {
   padding: 10px 12px;
   background: transparent;
@@ -897,6 +909,10 @@ main > .section:first-of-type {
   position: relative;
   transition: all .3s ease;
   min-height: 44px;
+}
+
+.glass-section .seg-btn {
+  color: #f5f5f5;
 }
 
 .seg-btn.is-active {


### PR DESCRIPTION
## Summary
- add a shared glass-section class to the gallery, services, about, and contact sections on the home page
- define reusable glass-section styling and adjust segbar colors for readability against the darker background
- correct the root CSS variable block so the stylesheet parses without syntax errors

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot proceed non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68def505eb80832797635dfa477ef796